### PR TITLE
Make element selection more specific

### DIFF
--- a/suit_ckeditor/widgets.py
+++ b/suit_ckeditor/widgets.py
@@ -23,6 +23,6 @@ class CKEditorWidget(Textarea):
     def render(self, name, value, attrs=None):
         output = super(CKEditorWidget, self).render(name, value, attrs)
         output += mark_safe(
-            '<script type="text/javascript">CKEDITOR.replace("%s", %s);</script>'
+            '<script type="text/javascript">CKEDITOR.replace("id_%s", %s);</script>'
             % (name, json.dumps(self.editor_options)))
         return output


### PR DESCRIPTION
CKEDITOR.replace() uses very wide search by id or element name.
Example: name field "content", and it will find not the textarea with
field value, but div id="content" from django-suit theme.

Adding id_ helps a little to eliminate name conflicts.

Screenshots of example:
![ckeditor-wrong](https://cloud.githubusercontent.com/assets/550335/5728681/1b35d8be-9b7d-11e4-96df-6186f5fe81d4.png)
![ckeditor-right](https://cloud.githubusercontent.com/assets/550335/5728684/22eb7c58-9b7d-11e4-8060-90245b771a31.png)
