### PR TITLE
adding id_ prefix in CKEditor replace

### DIFF
--- a/suit_ckeditor/widgets.py
+++ b/suit_ckeditor/widgets.py
@@ -23,6 +23,6 @@ class CKEditorWidget(Textarea):
     def render(self, name, value, attrs=None):
         output = super(CKEditorWidget, self).render(name, value, attrs)
         output += mark_safe(
-            '<script type="text/javascript">CKEDITOR.replace("%s", %s);</script>'
+            '<script type="text/javascript">CKEDITOR.replace("id_%s", %s);</script>'
             % (name, json.dumps(self.editor_options)))
         return output


### PR DESCRIPTION
To make sure only textarea tag will be converted into ckeditor.
Solving bug happened when field name is same as other element id (e.g. field that use name "content")
