### PR TITLE
Django 3.0 compatibility fix

### DIFF
--- a/suit_ckeditor/widgets.py
+++ b/suit_ckeditor/widgets.py
@@ -20,7 +20,7 @@ class CKEditorWidget(Textarea):
         self.editor_options = editor_options or {}
 
 
-    def render(self, name, value, attrs=None):
+    def render(self, name, value, attrs=None, renderer=None):
         output = super(CKEditorWidget, self).render(name, value, attrs)
         output += mark_safe(
             '<script type="text/javascript">CKEDITOR.replace("%s", %s);</script>'

--- a/suit_ckeditor/widgets.py
+++ b/suit_ckeditor/widgets.py
@@ -21,7 +21,7 @@ class CKEditorWidget(Textarea):
 
 
     def render(self, name, value, attrs=None, renderer=None):
-        output = super(CKEditorWidget, self).render(name, value, attrs)
+        output = super(CKEditorWidget, self).render(name, value, attrs, renderer)
         output += mark_safe(
             '<script type="text/javascript">CKEDITOR.replace("%s", %s);</script>'
             % (name, json.dumps(self.editor_options)))


### PR DESCRIPTION
Django 3.0 added a `renderer` kwarg to `Widget.render()`, which was causing `CKEditorWidget` to crash when the form is rendered. This fixes the problem, and `django-suit-ckeditor` is now fully functional in Django 3.0, as far as I can tell.